### PR TITLE
fix use '!include path/to/file' when --umlLocation 'remote'

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -584,30 +584,30 @@ function plugin (plugins, pluginEndCallback) {
 		var match,
 				index = 0,
 				segments = [],
-        tmpUmlStringArray = [],
-        tmpIncludePath = '',
+				tmpUmlStringArray = [],
+				tmpIncludePath = '',
 				opLocation = LocationOption();
-
+		
 		// if we have comment body text look for uml blocks
-		if(text) {
+		if (text) {
 			while ((match = umlExpression.exec(text)) != null) {
 				segments.push(text.substring(index, match.index));
-        // uml data used include and use remote. replace uml data to inclued file.
-        if (opLocation === "remote" && match[2].indexOf("!include") !== -1) {
-          tmpUmlStringArray = match[2].split('\n');
-          
-          for (var i = 0, len = tmpUmlStringArray.length; i < len; i++) {
-            tmpIncludePath = tmpUmlStringArray[i].replace("!include ", "");
-            if (tmpUmlStringArray[i].indexOf("!include") !== -1) {
-              var importPath = path.join(process.cwd(), tmpIncludePath);
-              if(fs.statSync(importPath).isFile()) {
-                var data = fs.readFileSync(importPath, "utf8");
-                match[2] = match[2].replace(tmpUmlStringArray[i], data);
-              }
-            }
-          }
-        }
-        				// replace the uml block with the image link, which will later be generated.
+				// uml data used include and use remote. replace uml data to inclued file.
+				if (opLocation === 'remote' && match[2].indexOf('!include') !== -1) {
+					tmpUmlStringArray = match[2].split('\n');
+					
+					for (var i = 0, len = tmpUmlStringArray.length; i < len; i++) {
+						tmpIncludePath = tmpUmlStringArray[i].replace('!include ', '');
+						if (tmpUmlStringArray[i].indexOf('!include') !== -1) {
+							var importPath = path.join(process.cwd(), tmpIncludePath);
+							if (fs.statSync(importPath).isFile()) {
+								var data = fs.readFileSync(importPath, 'utf8');
+								match[2] = match[2].replace(tmpUmlStringArray[i], data);
+							}
+						}
+					}
+				}
+				// replace the uml block with the image link, which will later be generated.
 				if (match[2]) {
 					segments.push("![");
 					if (match[1]) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -583,12 +583,31 @@ function plugin (plugins, pluginEndCallback) {
 	function processComment(text) {
 		var match,
 				index = 0,
-				segments = [];
+				segments = [],
+        tmpUmlStringArray = [],
+        tmpIncludePath = '',
+				opLocation = LocationOption();
+
 		// if we have comment body text look for uml blocks
 		if(text) {
 			while ((match = umlExpression.exec(text)) != null) {
 				segments.push(text.substring(index, match.index));
-				// replace the uml block with the image link, which will later be generated.
+        // uml data used include and use remote. replace uml data to inclued file.
+        if (opLocation === "remote" && match[2].indexOf("!include") !== -1) {
+          tmpUmlStringArray = match[2].split('\n');
+          
+          for (var i = 0, len = tmpUmlStringArray.length; i < len; i++) {
+            tmpIncludePath = tmpUmlStringArray[i].replace("!include ", "");
+            if (tmpUmlStringArray[i].indexOf("!include") !== -1) {
+              var importPath = path.join(process.cwd(), tmpIncludePath);
+              if(fs.statSync(importPath).isFile()) {
+                var data = fs.readFileSync(importPath, "utf8");
+                match[2] = match[2].replace(tmpUmlStringArray[i], data);
+              }
+            }
+          }
+        }
+        				// replace the uml block with the image link, which will later be generated.
 				if (match[2]) {
 					segments.push("![");
 					if (match[1]) {

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "typedocplugin"
   ],
   "dependencies": {
-    "node-plantuml": "^0.4.4",
+    "node-plantuml": "^0.7.0",
     "pako": "^1.0.0",
-    "progress": "^1.1.8"
+    "progress": "^2.0.0"
   },
   "devDependencies": {
-    "dir-compare": "0.0.2",
+    "dir-compare": "1.4.0",
     "rimraf": "^2.5.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "rimraf": "^2.5.1"
   },
   "peerDependencies": {
-    "typedoc": "^0.4.1"
+    "typedoc": "^0.12.0"
   }
 }


### PR DESCRIPTION
## current
use `!inluce path/to/file` and set `umlLocation='remote'`.
encode string is `!include /path/to/file`.

### example
```
// sample.ts
/**
 * <uml>
    !include path/to/file.puml
 * </uml>
 */
```
a got image is
 ![kypciyufjkblq2z8bcdgbydnjylcigk0](https://user-images.githubusercontent.com/31531668/34925460-bf5f5ea8-f9ec-11e7-948c-c9b018fa3370.png)

## after 
check `path/to/file.puml` file and replace `!include path/to/file.puml`

### example 
```
// sample.ts
/**
 * <uml>
    !include path/to/file.puml
 * </uml>
 */
```

```
# file.puml
@startuml
Bob -> Alice : hello
@enduml
```

a got image is 
![syffkj2rkt3coknelr1io4zdosa70000](https://user-images.githubusercontent.com/31531668/34925526-333c07a4-f9ed-11e7-9851-3de1d6085112.png)
